### PR TITLE
Supporting System.Serialize Types.

### DIFF
--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using AOT;
 using System;
 using SimpleJSON;
-using System.Xml.Xsl;
 
 namespace Playroom
 {
@@ -64,7 +63,7 @@ namespace Playroom
                 OnDisconnectCallback = onDisconnectCallback;
                 string optionsJson = null;
                 if (options != null) { optionsJson = SerializeInitOptions(options); }
-                InsertCoinInternal(optionsJson ,InvokeInsertCoin,__OnPlayerJoinCallbackHandler, __OnQuitInternalHandler, onDisconnectCallbackHandler);
+                InsertCoinInternal(optionsJson, InvokeInsertCoin, __OnPlayerJoinCallbackHandler, __OnQuitInternalHandler, onDisconnectCallbackHandler);
             }
             else
             {
@@ -1114,6 +1113,26 @@ namespace Playroom
                 }
             }
 
+            public void SetState(string key, object value, bool reliable = false)
+            {
+                if (IsRunningInBrowser())
+                {
+                    SetStateString(key, JsonUtility.ToJson(value), reliable);
+                }
+                else
+                {
+                    if (!isPlayRoomInitialized)
+                    {
+                        Debug.LogError("[Mock Mode] Playroom not initialized yet! Please call InsertCoin.");
+                    }
+                    else
+                    {
+                        Debug.Log($"State Set! Key: {key}, Value: {value}");
+                        MockSetState(key, value);
+                    }
+                }
+            }
+
             public T GetState<T>(string key)
             {
                 if (IsRunningInBrowser())
@@ -1136,8 +1155,7 @@ namespace Playroom
                     }
                     else
                     {
-                        Debug.LogError($"GetState<{typeof(T)}> is not supported.");
-                        return default;
+                        return JsonUtility.FromJson<T>(GetStateString(key));
                     }
                 }
                 else


### PR DESCRIPTION
- Added Support for System.Serialize types. 

This is how I used it:
```C#
Vector3 pos = playerGameObjects[index].GetComponent<Transform>().position;
players[index].SetState("posX", pos);
```
and to get:
```C#
 var newPos = players[i].GetState<Vector3>("posX");
 Debug.Log(newPos);
```

**Result of Test build:**
![image](https://github.com/asadm/playroom-unity/assets/77355191/10c9b12d-f2bc-46d3-9263-f2b19d173d7b)
> shows vector3 position of the player.

These changes didn't break anything else (currently only tested with Vector3).

Should resolve #32 and #20.