### PR TITLE
docs: update issue template to add discord link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -22,7 +22,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of our software are you running?
+      description: What version of the SDK are you running? (PlayroomKit for Unity SDK)
       placeholder: x.x.x
     validations:
       required: true
@@ -32,6 +32,12 @@ body:
       label: What is your environment?
       description: Describe your project's environment. This will help us reproduce the issue.
       placeholder: Unity version, Browser, Operating System, etc
+  - type: input
+    id: chat-url
+    attributes:
+      label: Link to original discussion
+      description: Relevant chat URL, such as a Discord message link, Slack message link, GitHub Issue, etc.
+      placeholder: https://discord.com/channels/997752993598419044/link-to-chat
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -14,3 +14,9 @@ body:
       value: "Better developer experience!"
     validations:
       required: true
+  - type: input
+    id: chat-url
+    attributes:
+      label: Link to original discussion
+      description: Relevant chat URL, such as a Discord message link, Slack message link, GitHub Issue, etc.
+      placeholder: https://discord.com/channels/997752993598419044/link-to-chat


### PR DESCRIPTION
Added an option to attach a Discord chat link, something we normally do.