### PR TITLE
Fix: RPC event being overridden

### DIFF
--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -1005,14 +1005,17 @@ namespace Playroom
             HOST
         }
 
-        private static Action<string, string> RpcRegisterCallback = null;
+        private static List<Action<string, string>> rpcRegisterCallbacks = new();
+        private static List<string> rpcRegisteredEvents = new();
+        private static List<string> rpcCalledEvents = new();
 
         [DllImport("__Internal")]
         private extern static void RpcRegisterInternal(string name, Action<string, string> rpcRegisterCallback, string onResponseReturn = null);
 
         public static void RpcRegister(string name, Action<string, string> rpcRegisterCallback, string onResponseReturn = null)
         {
-            RpcRegisterCallback = rpcRegisterCallback;
+            rpcRegisterCallbacks.Add(rpcRegisterCallback);
+            rpcRegisteredEvents.Add(name);
             RpcRegisterInternal(name, InvokeRpcRegisterCallBack, onResponseReturn);
         }
 
@@ -1035,14 +1038,21 @@ namespace Playroom
             {
                 Debug.LogError(ex.Message);
             }
-            RpcRegisterCallback?.Invoke(dataJson, senderJson);
+
+            for (int i = 0; i < Math.Min(rpcRegisteredEvents.Count, rpcCalledEvents.Count); i++)
+            {
+                if (rpcRegisteredEvents[i] == rpcCalledEvents[i])
+                {
+                    rpcRegisterCallbacks[i].Invoke(dataJson, senderJson);
+                }
+            }
+
         }
 
         [DllImport("__Internal")]
         private extern static void RpcCallInternal(string name, string data, RpcMode mode, Action callbackOnResponse);
 
         private static Dictionary<string, List<Action>> OnResponseCallbacks = new Dictionary<string, List<Action>>();
-        private static List<string> RpcEventNames = new List<string>();
 
         public static void RpcCall(string name, object data, RpcMode mode, Action callbackOnResponse)
         {
@@ -1056,9 +1066,9 @@ namespace Playroom
             else
             {
                 OnResponseCallbacks.Add(name, new List<Action> { callbackOnResponse });
-                if (!RpcEventNames.Contains(name))
+                if (!rpcCalledEvents.Contains(name))
                 {
-                    RpcEventNames.Add(name);
+                    rpcCalledEvents.Add(name);
                 }
             }
 
@@ -1076,7 +1086,7 @@ namespace Playroom
         {
             var namesToRemove = new List<string>();
 
-            foreach (var name in RpcEventNames)
+            foreach (var name in rpcCalledEvents)
             {
                 try
                 {
@@ -1098,7 +1108,7 @@ namespace Playroom
 
             foreach (var name in namesToRemove)
             {
-                RpcEventNames.Remove(name);
+                rpcCalledEvents.Remove(name);
                 OnResponseCallbacks.Remove(name);
             }
         }

--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -1005,14 +1005,22 @@ namespace Playroom
             HOST
         }
 
-        private static Action<string, string> RpcRegisterCallback = null;
+        private static Dictionary<string, Action<string, string>> RpcRegisterCallbacks = new Dictionary<string, Action<string, string>>();
 
         [DllImport("__Internal")]
         private extern static void RpcRegisterInternal(string name, Action<string, string> rpcRegisterCallback, string onResponseReturn = null);
 
         public static void RpcRegister(string name, Action<string, string> rpcRegisterCallback, string onResponseReturn = null)
         {
-            RpcRegisterCallback = rpcRegisterCallback;
+            if (!RpcRegisterCallbacks.ContainsKey(name))
+            {
+                RpcRegisterCallbacks.Add(name, rpcRegisterCallback);
+            }
+            else
+            {
+                Debug.LogWarning($"Callback for RPC '{name}' already registered.");
+            }
+
             RpcRegisterInternal(name, InvokeRpcRegisterCallBack, onResponseReturn);
         }
 
@@ -1035,8 +1043,11 @@ namespace Playroom
             {
                 Debug.LogError(ex.Message);
             }
-            RpcRegisterCallback?.Invoke(dataJson, senderJson);
+
+            // TODO: Invoke the callback if name exists and is called?
+
         }
+
 
         [DllImport("__Internal")]
         private extern static void RpcCallInternal(string name, string data, RpcMode mode, Action callbackOnResponse);

--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -1005,22 +1005,14 @@ namespace Playroom
             HOST
         }
 
-        private static Dictionary<string, Action<string, string>> RpcRegisterCallbacks = new Dictionary<string, Action<string, string>>();
+        private static Action<string, string> RpcRegisterCallback = null;
 
         [DllImport("__Internal")]
         private extern static void RpcRegisterInternal(string name, Action<string, string> rpcRegisterCallback, string onResponseReturn = null);
 
         public static void RpcRegister(string name, Action<string, string> rpcRegisterCallback, string onResponseReturn = null)
         {
-            if (!RpcRegisterCallbacks.ContainsKey(name))
-            {
-                RpcRegisterCallbacks.Add(name, rpcRegisterCallback);
-            }
-            else
-            {
-                Debug.LogWarning($"Callback for RPC '{name}' already registered.");
-            }
-
+            RpcRegisterCallback = rpcRegisterCallback;
             RpcRegisterInternal(name, InvokeRpcRegisterCallBack, onResponseReturn);
         }
 
@@ -1043,11 +1035,8 @@ namespace Playroom
             {
                 Debug.LogError(ex.Message);
             }
-
-            // TODO: Invoke the callback if name exists and is called?
-
+            RpcRegisterCallback?.Invoke(dataJson, senderJson);
         }
-
 
         [DllImport("__Internal")]
         private extern static void RpcCallInternal(string name, string data, RpcMode mode, Action callbackOnResponse);

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -47,7 +47,6 @@ public class GameManager : MonoBehaviour
     void Start()
     {
         PlayroomKit.RpcRegister("ShootBullet", HandleScoreUpdate, "You shot a bullet!");
-        PlayroomKit.RpcRegister("Hello", Hello, "You said Hello!");
     }
 
     void HandleScoreUpdate(string data, string caller)
@@ -152,11 +151,6 @@ public class GameManager : MonoBehaviour
         playerJoined = true;
 
         player.OnQuit(RemovePlayer);
-    }
-
-    void Hello(string data, string caller)
-    {
-        Debug.Log($"Hello! said by {caller}");
     }
 
     [MonoPInvokeCallback(typeof(Action<string>))]

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -47,6 +47,12 @@ public class GameManager : MonoBehaviour
     void Start()
     {
         PlayroomKit.RpcRegister("ShootBullet", HandleScoreUpdate, "You shot a bullet!");
+        PlayroomKit.RpcRegister("Hello", Hello, "You said Hello!");
+    }
+
+    void Hello(string data, string caller)
+    {
+        Debug.Log($"Hello! said by {caller}");
     }
 
     void HandleScoreUpdate(string data, string caller)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -47,6 +47,7 @@ public class GameManager : MonoBehaviour
     void Start()
     {
         PlayroomKit.RpcRegister("ShootBullet", HandleScoreUpdate, "You shot a bullet!");
+        PlayroomKit.RpcRegister("Hello", Hello, "You said Hello!");
     }
 
     void HandleScoreUpdate(string data, string caller)
@@ -151,6 +152,11 @@ public class GameManager : MonoBehaviour
         playerJoined = true;
 
         player.OnQuit(RemovePlayer);
+    }
+
+    void Hello(string data, string caller)
+    {
+        Debug.Log($"Hello! said by {caller}");
     }
 
     [MonoPInvokeCallback(typeof(Action<string>))]


### PR DESCRIPTION
Based on #59 

I have tested the scenario explained in the issue, The previous RPC registered callback gets overridden when we subscribe to a new one.

 ```C#
PlayroomKit.RpcRegister("ShootBullet", HandleScoreUpdate, "You shot a bullet!");
PlayroomKit.RpcRegister("Hello", Hello, "You said Hello!");
 ```
And I only call the first one:
 ```C#
   PlayroomKit.RpcCall("ShootBullet", score, () =>
  {
      Debug.Log("shooting bullet!");
  });
 ```
  
This should only Invoke `HandleScoreUpdate()`, but that gets overridden by `Hello`.


Currently the issue how to filter the correct Rpc Event Names to invoke only the callback associated with the name. 
 