### PR TITLE
Non-Upstream Functions Private

### DIFF
--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -285,7 +285,7 @@ namespace Playroom
             }
         }
 
-        public static void UnsubscribeOnPlayerJoin(string CallbackID)
+        private static void UnsubscribeOnPlayerJoin(string CallbackID)
         {
             UnsubscribeOnPlayerJoinInternal(CallbackID);
         }
@@ -922,7 +922,7 @@ namespace Playroom
         [DllImport("__Internal")]
         private static extern void UnsubscribeOnQuitInternal();
 
-        public static void UnsubscribeOnQuit()
+        private static void UnsubscribeOnQuit()
         {
             UnsubscribeOnQuitInternal();
         }
@@ -1245,7 +1245,7 @@ namespace Playroom
         }
 
         [DllImport("__Internal")]
-        public static extern void StartMatchmakingInternal(Action callback);
+        private static extern void StartMatchmakingInternal(Action callback);
 
         static Action startMatchmakingCallback = null;
         public static void StartMatchmaking(Action callback = null)
@@ -1297,7 +1297,7 @@ namespace Playroom
 
 
             public string id;
-            public static int totalObjects = 0;
+            private static int totalObjects = 0;
 
 
             public Player(string id)

--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -936,7 +936,7 @@ namespace Playroom
         {
             if (Players.TryGetValue(playerId, out Player player))
             {
-                player.OnQuitWrapperCallback();
+                ((IPlayerInteraction)player).InvokeOnQuitWrapperCallback();
             }
             else
             {
@@ -1272,7 +1272,13 @@ namespace Playroom
         }
 
         // Player class
-        public class Player
+
+        public interface IPlayerInteraction
+        {
+            void InvokeOnQuitWrapperCallback();
+        }
+
+        public class Player : IPlayerInteraction
         {
 
             [Serializable]
@@ -1336,11 +1342,16 @@ namespace Playroom
             }
 
             [MonoPInvokeCallback(typeof(Action))]
-            public void OnQuitWrapperCallback()
+            private void OnQuitWrapperCallback()
             {
                 if (OnQuitCallbacks != null)
                     foreach (var callback in OnQuitCallbacks)
                         callback?.Invoke(id);
+            }
+
+            void IPlayerInteraction.InvokeOnQuitWrapperCallback()
+            {
+                OnQuitWrapperCallback();
             }
 
             public Action OnQuit(Action<string> callback)
@@ -1875,6 +1886,8 @@ namespace Playroom
                 // Output the JSON string
                 SetPlayerStateDictionary(id, key, jsonString, reliable);
             }
+
+
         }
     }
 

--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -704,6 +704,10 @@ namespace Playroom
                 {
                     return (T)(object)GetStateString(key);
                 }
+                else if (typeof(T).IsGenericType && typeof(T).GetGenericTypeDefinition() == typeof(Dictionary<string, T>))
+                {
+                    return (T)(object)GetStateDict<object>(key);
+                }
                 else
                 {
                     Debug.LogError($"GetState<{typeof(T)}> is not supported.");
@@ -768,7 +772,7 @@ namespace Playroom
         [DllImport("__Internal")]
         private static extern string GetStateDictionaryInternal(string key);
 
-        public static Dictionary<string, T> GetStateDict<T>(string key)
+        private static Dictionary<string, T> GetStateDict<T>(string key)
         {
             if (IsRunningInBrowser())
             {
@@ -1073,7 +1077,7 @@ namespace Playroom
                     var player = new Player(senderJson);
                     Players.Add(senderJson, player);
                 }
-                
+
             }
             catch (Exception ex)
             {
@@ -1473,6 +1477,10 @@ namespace Playroom
                     else if (type == typeof(Vector3)) return (T)(object)JsonUtility.FromJson<Vector3>(GetPlayerStateStringById(id, key));
                     else if (type == typeof(Vector2)) return (T)(object)JsonUtility.FromJson<Vector2>(GetPlayerStateStringById(id, key));
                     else if (type == typeof(Quaternion)) return (T)(object)JsonUtility.FromJson<Quaternion>(GetPlayerStateStringById(id, key));
+                    else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<string, T>))
+                    {
+                        return (T)(object)GetStateDict<T>(key);
+                    }
                     else throw new NotSupportedException($"Type {typeof(T)} is not supported by GetState");
                 }
                 else
@@ -1490,7 +1498,7 @@ namespace Playroom
             }
 
 
-            public Dictionary<string, T> GetStateDict<T>(string key)
+            private Dictionary<string, T> GetStateDict<T>(string key)
             {
                 if (IsRunningInBrowser())
                 {

--- a/Assets/PlayroomKit/PlayroomKit.cs
+++ b/Assets/PlayroomKit/PlayroomKit.cs
@@ -595,7 +595,7 @@ namespace Playroom
         [DllImport("__Internal")]
         private static extern string GetStateStringInternal(string key);
 
-        public static string GetStateString(string key)
+        private static string GetStateString(string key)
         {
             if (IsRunningInBrowser())
             {
@@ -618,7 +618,7 @@ namespace Playroom
         [DllImport("__Internal")]
         private static extern int GetStateIntInternal(string key);
 
-        public static int GetStateInt(string key)
+        private static int GetStateInt(string key)
         {
             if (IsRunningInBrowser())
             {
@@ -641,7 +641,7 @@ namespace Playroom
         [DllImport("__Internal")]
         private static extern float GetStateFloatInternal(string key);
 
-        public static float GetStateFloat(string key)
+        private static float GetStateFloat(string key)
         {
             if (IsRunningInBrowser())
             {
@@ -661,7 +661,7 @@ namespace Playroom
             }
         }
 
-        public static bool GetStateBool(string key)
+        private static bool GetStateBool(string key)
         {
             if (IsRunningInBrowser())
             {
@@ -1073,10 +1073,7 @@ namespace Playroom
                     var player = new Player(senderJson);
                     Players.Add(senderJson, player);
                 }
-                else
-                {
-                    Debug.LogWarning($"Players dictionary already has a player with ID: {senderJson}!");
-                }
+                
             }
             catch (Exception ex)
             {
@@ -1514,7 +1511,7 @@ namespace Playroom
                 }
             }
 
-            public int GetPlayerStateInt(string key)
+            private int GetPlayerStateInt(string key)
             {
                 if (IsRunningInBrowser())
                 {
@@ -1534,7 +1531,7 @@ namespace Playroom
                 }
             }
 
-            public float GetPlayerStateFloat(string key)
+            private float GetPlayerStateFloat(string key)
             {
                 if (IsRunningInBrowser())
                 {
@@ -1554,7 +1551,7 @@ namespace Playroom
                 }
             }
 
-            public string GetPlayerStateString(string key)
+            private string GetPlayerStateString(string key)
             {
                 if (IsRunningInBrowser())
                 {
@@ -1574,7 +1571,7 @@ namespace Playroom
                 }
             }
 
-            public bool GetPlayerStateBool(string key)
+            private bool GetPlayerStateBool(string key)
             {
                 if (IsRunningInBrowser())
                 {
@@ -1685,12 +1682,6 @@ namespace Playroom
                         MockSetState(key, values);
                     }
                 }
-            }
-
-            public Dictionary<string, float> GetStateFloat(string id, string key)
-            {
-                var jsonString = GetPlayerStateDictionary(id, key);
-                return ParseJsonToDictionary<float>(jsonString);
             }
 
             public void WaitForState(string StateKey, Action onStateSetCallback = null)
@@ -1818,7 +1809,7 @@ namespace Playroom
             private static extern void WaitForPlayerStateInternal(string playerID, string stateKey, Action onStateSetCallback = null);
 
 
-            public static bool GetPlayerStateBoolById(string id, string key)
+            private static bool GetPlayerStateBoolById(string id, string key)
             {
                 if (IsRunningInBrowser())
                 {


### PR DESCRIPTION
* Made all non-upstream functions private #72
* Removed unnecessary warning log in RPC.
* Removed `GetStateFloat` in Player class, because there already is `GetStateDict`