### PR TITLE
fix: onQuit not updating internal player list

### DIFF
--- a/Assets/PlayroomKit/modules/Player/PlayerService.cs
+++ b/Assets/PlayroomKit/modules/Player/PlayerService.cs
@@ -1,10 +1,8 @@
+using AOT;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using UnityEngine;
-using System.Runtime.InteropServices;
-using AOT;
 
 namespace Playroom
 {
@@ -218,9 +216,10 @@ namespace Playroom
                     IPlayerBase.onKickCallBack?.Invoke();
                 }
 
-                [MonoPInvokeCallback(typeof(Action))]
+                [MonoPInvokeCallback(typeof(Action<string>))]
                 public void OnQuitWrapperCallback(string id)
                 {
+                    Players.Remove(id);
                     if (OnQuitCallbacks != null)
                         foreach (var callback in OnQuitCallbacks)
                             callback?.Invoke(id);


### PR DESCRIPTION
Player object list is being maintained internally on the Unity side.
onQuit callback did not clear internal list causing issues:
-  #89: GetPlayers() count returns incorrectly (publicly exposed)
- Prior onQuit Callback assignment for same player retained which conflicted on player rejoin